### PR TITLE
Fix getCustomName() in EntityMeta, update protocolVersion for 1.20.6, new method to use MetaData in packetevents listener

### DIFF
--- a/api/src/main/java/me/tofaa/entitylib/meta/EntityMeta.java
+++ b/api/src/main/java/me/tofaa/entitylib/meta/EntityMeta.java
@@ -150,7 +150,7 @@ public class EntityMeta implements EntityMetadataProvider {
     }
 
     public Component getCustomName() {
-        Optional<Component> component = this.metadata.getIndex(customNameOffset(), null);
+        Optional<Component> component = this.metadata.getIndex(customNameOffset(), Optional.empty());
         return component.orElse(null);
     }
 

--- a/api/src/main/java/me/tofaa/entitylib/meta/MetaOffsetConverter.java
+++ b/api/src/main/java/me/tofaa/entitylib/meta/MetaOffsetConverter.java
@@ -14,7 +14,7 @@ public final class MetaOffsetConverter {
     public static final class EntityMetaOffsets {
         public static byte airTicksOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 47 && protocolVersion <= 765) {
+            if (protocolVersion >= 47 && protocolVersion <= 766) {
                 return 1;
             }
             throw new RuntimeException("Unknown protocol version for this method");
@@ -22,7 +22,7 @@ public final class MetaOffsetConverter {
 
         public static byte customNameOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 47 && protocolVersion <= 765) {
+            if (protocolVersion >= 47 && protocolVersion <= 766) {
                 return 2;
             }
             throw new RuntimeException("Unknown protocol version for this method");
@@ -30,7 +30,7 @@ public final class MetaOffsetConverter {
 
         public static byte customNameVisibleOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 47 && protocolVersion <= 765) {
+            if (protocolVersion >= 47 && protocolVersion <= 766) {
                 return 3;
             }
             throw new RuntimeException("Unknown protocol version for this method");
@@ -38,7 +38,7 @@ public final class MetaOffsetConverter {
 
         public static byte silentOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 47 && protocolVersion <= 765) {
+            if (protocolVersion >= 47 && protocolVersion <= 766) {
                 return 4;
             }
             throw new RuntimeException("Unknown protocol version for this method");
@@ -46,7 +46,7 @@ public final class MetaOffsetConverter {
 
         public static byte hasNoGravityOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 47 && protocolVersion <= 765) {
+            if (protocolVersion >= 47 && protocolVersion <= 766) {
                 return 5;
             }
             throw new RuntimeException("Unknown protocol version for this method");
@@ -54,7 +54,7 @@ public final class MetaOffsetConverter {
 
         public static byte poseOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 47 && protocolVersion <= 765) {
+            if (protocolVersion >= 47 && protocolVersion <= 766) {
                 return 6;
             }
             throw new RuntimeException("Unknown protocol version for this method");
@@ -62,7 +62,7 @@ public final class MetaOffsetConverter {
 
         public static byte ticksFrozenInPowderedSnowOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 47 && protocolVersion <= 765) {
+            if (protocolVersion >= 47 && protocolVersion <= 766) {
                 return 7;
             }
             throw new RuntimeException("Unknown protocol version for this method");
@@ -72,7 +72,7 @@ public final class MetaOffsetConverter {
     public static final class AbstractDisplayMetaOffsets {
         public static byte interpolationDelayOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 762 && protocolVersion <= 765) {
+            if (protocolVersion >= 762 && protocolVersion <= 766) {
                 return 8;
             }
             throw new RuntimeException("Unknown protocol version for this method");
@@ -80,7 +80,7 @@ public final class MetaOffsetConverter {
 
         public static byte transformationDurationOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 762 && protocolVersion <= 765) {
+            if (protocolVersion >= 762 && protocolVersion <= 766) {
                 return 9;
             }
             throw new RuntimeException("Unknown protocol version for this method");
@@ -88,7 +88,7 @@ public final class MetaOffsetConverter {
 
         public static byte positionRotationInterpolationDurationOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 765) {
+            if (protocolVersion >= 764 && protocolVersion <= 766) {
                 return 10;
             }
             throw new RuntimeException("Unknown protocol version for this method");
@@ -96,7 +96,7 @@ public final class MetaOffsetConverter {
 
         public static byte translationOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 765) {
+            if (protocolVersion >= 764 && protocolVersion <= 766) {
                 return 11;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -107,7 +107,7 @@ public final class MetaOffsetConverter {
 
         public static byte scaleOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 765) {
+            if (protocolVersion >= 764 && protocolVersion <= 766) {
                 return 12;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -118,7 +118,7 @@ public final class MetaOffsetConverter {
 
         public static byte leftRotationOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 765) {
+            if (protocolVersion >= 764 && protocolVersion <= 766) {
                 return 13;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -129,7 +129,7 @@ public final class MetaOffsetConverter {
 
         public static byte rightRotationOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 765) {
+            if (protocolVersion >= 764 && protocolVersion <= 766) {
                 return 14;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -140,7 +140,7 @@ public final class MetaOffsetConverter {
 
         public static byte billboardConstraintsOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 765) {
+            if (protocolVersion >= 764 && protocolVersion <= 766) {
                 return 15;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -151,7 +151,7 @@ public final class MetaOffsetConverter {
 
         public static byte brightnessOverrideOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 765) {
+            if (protocolVersion >= 764 && protocolVersion <= 766) {
                 return 16;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -162,7 +162,7 @@ public final class MetaOffsetConverter {
 
         public static byte viewRangeOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 765) {
+            if (protocolVersion >= 764 && protocolVersion <= 766) {
                 return 17;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -173,7 +173,7 @@ public final class MetaOffsetConverter {
 
         public static byte shadowRadiusOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 765) {
+            if (protocolVersion >= 764 && protocolVersion <= 766) {
                 return 18;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -184,7 +184,7 @@ public final class MetaOffsetConverter {
 
         public static byte shadowStrengthOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 765) {
+            if (protocolVersion >= 764 && protocolVersion <= 766) {
                 return 19;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -195,7 +195,7 @@ public final class MetaOffsetConverter {
 
         public static byte widthOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 765) {
+            if (protocolVersion >= 764 && protocolVersion <= 766) {
                 return 20;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -206,7 +206,7 @@ public final class MetaOffsetConverter {
 
         public static byte heightOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 765) {
+            if (protocolVersion >= 764 && protocolVersion <= 766) {
                 return 21;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -217,7 +217,7 @@ public final class MetaOffsetConverter {
 
         public static byte glowColorOverrideOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 765) {
+            if (protocolVersion >= 764 && protocolVersion <= 766) {
                 return 22;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -230,7 +230,7 @@ public final class MetaOffsetConverter {
     public static final class BlockDisplayMetaOffsets {
         public static byte blockIdOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 765) {
+            if (protocolVersion >= 764 && protocolVersion <= 766) {
                 return 23;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -243,7 +243,7 @@ public final class MetaOffsetConverter {
     public static final class ItemDisplayMetaOffsets {
         public static byte itemOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 765) {
+            if (protocolVersion >= 764 && protocolVersion <= 766) {
                 return 24;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -254,7 +254,7 @@ public final class MetaOffsetConverter {
 
         public static byte displayTypeOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 765) {
+            if (protocolVersion >= 764 && protocolVersion <= 766) {
                 return 25;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -267,7 +267,7 @@ public final class MetaOffsetConverter {
     public static final class TextDisplayMetaOffsets {
         public static byte textOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 765) {
+            if (protocolVersion >= 764 && protocolVersion <= 766) {
                 return 26;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -278,7 +278,7 @@ public final class MetaOffsetConverter {
 
         public static byte textColorOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 765) {
+            if (protocolVersion >= 764 && protocolVersion <= 766) {
                 return 27;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -289,7 +289,7 @@ public final class MetaOffsetConverter {
 
         public static byte textBackgroundColorOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 765) {
+            if (protocolVersion >= 764 && protocolVersion <= 766) {
                 return 28;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -300,7 +300,7 @@ public final class MetaOffsetConverter {
 
         public static byte textBackgroundOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 765) {
+            if (protocolVersion >= 764 && protocolVersion <= 766) {
                 return 29;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -311,7 +311,7 @@ public final class MetaOffsetConverter {
 
         public static byte textScaleOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 765) {
+            if (protocolVersion >= 764 && protocolVersion <= 766) {
                 return 30;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -322,7 +322,7 @@ public final class MetaOffsetConverter {
 
         public static byte textAlignmentOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 765) {
+            if (protocolVersion >= 764 && protocolVersion <= 766) {
                 return 31;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -333,7 +333,7 @@ public final class MetaOffsetConverter {
 
         public static byte lineWidthOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 765) {
+            if (protocolVersion >= 764 && protocolVersion <= 766) {
                 return 32;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -344,7 +344,7 @@ public final class MetaOffsetConverter {
 
         public static byte backgroundColorOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 765) {
+            if (protocolVersion >= 764 && protocolVersion <= 766) {
                 return 33;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -355,7 +355,7 @@ public final class MetaOffsetConverter {
 
         public static byte textOpacityOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 765) {
+            if (protocolVersion >= 764 && protocolVersion <= 766) {
                 return 34;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -366,7 +366,7 @@ public final class MetaOffsetConverter {
 
         public static byte shadowOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 765) {
+            if (protocolVersion >= 764 && protocolVersion <= 766) {
                 return 35;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -377,7 +377,7 @@ public final class MetaOffsetConverter {
 
         public static byte seeThroughOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 765) {
+            if (protocolVersion >= 764 && protocolVersion <= 766) {
                 return 36;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -388,7 +388,7 @@ public final class MetaOffsetConverter {
 
         public static byte useDefaultBackgroundOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 765) {
+            if (protocolVersion >= 764 && protocolVersion <= 766) {
                 return 37;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -399,7 +399,7 @@ public final class MetaOffsetConverter {
 
         public static byte allighnLeftOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 765) {
+            if (protocolVersion >= 764 && protocolVersion <= 766) {
                 return 38;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -410,7 +410,7 @@ public final class MetaOffsetConverter {
 
         public static byte allighnRightOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 765) {
+            if (protocolVersion >= 764 && protocolVersion <= 766) {
                 return 39;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -421,7 +421,7 @@ public final class MetaOffsetConverter {
 
         public static byte allighnCenterOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 765) {
+            if (protocolVersion >= 764 && protocolVersion <= 766) {
                 return 40;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {

--- a/api/src/main/java/me/tofaa/entitylib/meta/Metadata.java
+++ b/api/src/main/java/me/tofaa/entitylib/meta/Metadata.java
@@ -2,6 +2,7 @@ package me.tofaa.entitylib.meta;
 
 import com.github.retrooper.packetevents.protocol.entity.data.EntityData;
 import com.github.retrooper.packetevents.protocol.entity.data.EntityDataType;
+import com.github.retrooper.packetevents.protocol.entity.data.EntityDataTypes;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerEntityMetadata;
 import me.tofaa.entitylib.EntityLib;
 import me.tofaa.entitylib.EntityLibAPI;
@@ -74,6 +75,11 @@ public class Metadata {
         entity.sendPacketsToViewers(packet);
     }
 
+    public void setMetaFromPacket(WrapperPlayServerEntityMetadata wrapper) {
+        for (EntityData data : wrapper.getEntityMetadata()) {
+            metadataMap.put((byte) data.getIndex(), data);
+        }
+    }
 
     public boolean isNotifyingChanges() {
         return notifyAboutChanges;


### PR DESCRIPTION
Fix getCustomName() in EntityMeta
Adding setMetaFromPacket method to use MetaData from EntityMetaPacket
Updating protocolVersion in MetaOffsetConverter for 1.20.6