### PR TITLE
PacketEvents 2.4.0 and Minecraft 1.21

### DIFF
--- a/api/src/main/java/me/tofaa/entitylib/EntityLib.java
+++ b/api/src/main/java/me/tofaa/entitylib/EntityLib.java
@@ -46,6 +46,6 @@ public final class EntityLib {
     }
 
     public static String getVersion() {
-        return "2.1.2-SNAPSHOT";
+        return "2.3.1-SNAPSHOT";
     }
 }

--- a/api/src/main/java/me/tofaa/entitylib/meta/MetaConverterRegistry.java
+++ b/api/src/main/java/me/tofaa/entitylib/meta/MetaConverterRegistry.java
@@ -16,6 +16,7 @@ import me.tofaa.entitylib.meta.mobs.monster.*;
 import me.tofaa.entitylib.meta.mobs.monster.piglin.PiglinBruteMeta;
 import me.tofaa.entitylib.meta.mobs.monster.piglin.PiglinMeta;
 import me.tofaa.entitylib.meta.mobs.monster.raider.*;
+import me.tofaa.entitylib.meta.mobs.monster.skeleton.BoggedMeta;
 import me.tofaa.entitylib.meta.mobs.monster.skeleton.SkeletonMeta;
 import me.tofaa.entitylib.meta.mobs.monster.skeleton.StrayMeta;
 import me.tofaa.entitylib.meta.mobs.monster.skeleton.WitherSkeletonMeta;
@@ -58,8 +59,8 @@ final class MetaConverterRegistry {
         put(BLAZE, BlazeMeta.class, BlazeMeta::new);
         put(BLOCK_DISPLAY, BlockDisplayMeta.class, BlockDisplayMeta::new);
         put(BOAT, BoatMeta.class, BoatMeta::new);
-        put(BOGGED, LivingEntityMeta.class, LivingEntityMeta::new); // TODO: Implement
-        put(BREEZE, LivingEntityMeta.class, LivingEntityMeta::new); // TODO: Implement
+        put(BOGGED, BoggedMeta.class, BoggedMeta::new); // TODO: Verify correctness
+        put(BREEZE, BreezeMeta.class, BreezeMeta::new); // TODO: Verify correctness
         put(BREEZE_WIND_CHARGE, SmallFireballMeta.class, SmallFireballMeta::new); // TODO: Verify correctness
         put(CAMEL, CamelMeta.class, CamelMeta::new); // TODO: Verify correctness
         put(CAT, CatMeta.class, CatMeta::new);

--- a/api/src/main/java/me/tofaa/entitylib/meta/MetaOffsetConverter.java
+++ b/api/src/main/java/me/tofaa/entitylib/meta/MetaOffsetConverter.java
@@ -9,12 +9,16 @@ import org.jetbrains.annotations.ApiStatus;
 @ApiStatus.Internal
 @SuppressWarnings("unused")
 public final class MetaOffsetConverter {
-    private MetaOffsetConverter() {}
+    private MetaOffsetConverter() {
+    }
 
     public static final class EntityMetaOffsets {
+        private EntityMetaOffsets() {
+        }
+
         public static byte airTicksOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 47 && protocolVersion <= 766) {
+            if (protocolVersion >= 47 && protocolVersion <= 767) {
                 return 1;
             }
             throw new RuntimeException("Unknown protocol version for this method");
@@ -22,7 +26,7 @@ public final class MetaOffsetConverter {
 
         public static byte customNameOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 47 && protocolVersion <= 766) {
+            if (protocolVersion >= 47 && protocolVersion <= 767) {
                 return 2;
             }
             throw new RuntimeException("Unknown protocol version for this method");
@@ -30,7 +34,7 @@ public final class MetaOffsetConverter {
 
         public static byte customNameVisibleOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 47 && protocolVersion <= 766) {
+            if (protocolVersion >= 47 && protocolVersion <= 767) {
                 return 3;
             }
             throw new RuntimeException("Unknown protocol version for this method");
@@ -38,7 +42,7 @@ public final class MetaOffsetConverter {
 
         public static byte silentOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 47 && protocolVersion <= 766) {
+            if (protocolVersion >= 47 && protocolVersion <= 767) {
                 return 4;
             }
             throw new RuntimeException("Unknown protocol version for this method");
@@ -46,7 +50,7 @@ public final class MetaOffsetConverter {
 
         public static byte hasNoGravityOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 47 && protocolVersion <= 766) {
+            if (protocolVersion >= 47 && protocolVersion <= 767) {
                 return 5;
             }
             throw new RuntimeException("Unknown protocol version for this method");
@@ -54,7 +58,7 @@ public final class MetaOffsetConverter {
 
         public static byte poseOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 47 && protocolVersion <= 766) {
+            if (protocolVersion >= 47 && protocolVersion <= 767) {
                 return 6;
             }
             throw new RuntimeException("Unknown protocol version for this method");
@@ -62,7 +66,7 @@ public final class MetaOffsetConverter {
 
         public static byte ticksFrozenInPowderedSnowOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 47 && protocolVersion <= 766) {
+            if (protocolVersion >= 47 && protocolVersion <= 767) {
                 return 7;
             }
             throw new RuntimeException("Unknown protocol version for this method");
@@ -70,9 +74,12 @@ public final class MetaOffsetConverter {
     }
 
     public static final class AbstractDisplayMetaOffsets {
+        private AbstractDisplayMetaOffsets() {
+        }
+
         public static byte interpolationDelayOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 762 && protocolVersion <= 766) {
+            if (protocolVersion >= 762 && protocolVersion <= 767) {
                 return 8;
             }
             throw new RuntimeException("Unknown protocol version for this method");
@@ -80,7 +87,7 @@ public final class MetaOffsetConverter {
 
         public static byte transformationDurationOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 762 && protocolVersion <= 766) {
+            if (protocolVersion >= 762 && protocolVersion <= 767) {
                 return 9;
             }
             throw new RuntimeException("Unknown protocol version for this method");
@@ -88,7 +95,7 @@ public final class MetaOffsetConverter {
 
         public static byte positionRotationInterpolationDurationOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 766) {
+            if (protocolVersion >= 764 && protocolVersion <= 767) {
                 return 10;
             }
             throw new RuntimeException("Unknown protocol version for this method");
@@ -96,7 +103,7 @@ public final class MetaOffsetConverter {
 
         public static byte translationOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 766) {
+            if (protocolVersion >= 764 && protocolVersion <= 767) {
                 return 11;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -107,7 +114,7 @@ public final class MetaOffsetConverter {
 
         public static byte scaleOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 766) {
+            if (protocolVersion >= 764 && protocolVersion <= 767) {
                 return 12;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -118,7 +125,7 @@ public final class MetaOffsetConverter {
 
         public static byte leftRotationOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 766) {
+            if (protocolVersion >= 764 && protocolVersion <= 767) {
                 return 13;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -129,7 +136,7 @@ public final class MetaOffsetConverter {
 
         public static byte rightRotationOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 766) {
+            if (protocolVersion >= 764 && protocolVersion <= 767) {
                 return 14;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -140,7 +147,7 @@ public final class MetaOffsetConverter {
 
         public static byte billboardConstraintsOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 766) {
+            if (protocolVersion >= 764 && protocolVersion <= 767) {
                 return 15;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -151,7 +158,7 @@ public final class MetaOffsetConverter {
 
         public static byte brightnessOverrideOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 766) {
+            if (protocolVersion >= 764 && protocolVersion <= 767) {
                 return 16;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -162,7 +169,7 @@ public final class MetaOffsetConverter {
 
         public static byte viewRangeOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 766) {
+            if (protocolVersion >= 764 && protocolVersion <= 767) {
                 return 17;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -173,7 +180,7 @@ public final class MetaOffsetConverter {
 
         public static byte shadowRadiusOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 766) {
+            if (protocolVersion >= 764 && protocolVersion <= 767) {
                 return 18;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -184,7 +191,7 @@ public final class MetaOffsetConverter {
 
         public static byte shadowStrengthOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 766) {
+            if (protocolVersion >= 764 && protocolVersion <= 767) {
                 return 19;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -195,7 +202,7 @@ public final class MetaOffsetConverter {
 
         public static byte widthOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 766) {
+            if (protocolVersion >= 764 && protocolVersion <= 767) {
                 return 20;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -206,7 +213,7 @@ public final class MetaOffsetConverter {
 
         public static byte heightOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 766) {
+            if (protocolVersion >= 764 && protocolVersion <= 767) {
                 return 21;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -217,7 +224,7 @@ public final class MetaOffsetConverter {
 
         public static byte glowColorOverrideOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 766) {
+            if (protocolVersion >= 764 && protocolVersion <= 767) {
                 return 22;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -228,9 +235,12 @@ public final class MetaOffsetConverter {
     }
 
     public static final class BlockDisplayMetaOffsets {
+        private BlockDisplayMetaOffsets() {
+        }
+
         public static byte blockIdOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 766) {
+            if (protocolVersion >= 764 && protocolVersion <= 767) {
                 return 23;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -241,9 +251,12 @@ public final class MetaOffsetConverter {
     }
 
     public static final class ItemDisplayMetaOffsets {
+        private ItemDisplayMetaOffsets() {
+        }
+
         public static byte itemOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 766) {
+            if (protocolVersion >= 764 && protocolVersion <= 767) {
                 return 24;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -254,7 +267,7 @@ public final class MetaOffsetConverter {
 
         public static byte displayTypeOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 766) {
+            if (protocolVersion >= 764 && protocolVersion <= 767) {
                 return 25;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -265,9 +278,12 @@ public final class MetaOffsetConverter {
     }
 
     public static final class TextDisplayMetaOffsets {
+        private TextDisplayMetaOffsets() {
+        }
+
         public static byte textOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 766) {
+            if (protocolVersion >= 764 && protocolVersion <= 767) {
                 return 26;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -278,7 +294,7 @@ public final class MetaOffsetConverter {
 
         public static byte textColorOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 766) {
+            if (protocolVersion >= 764 && protocolVersion <= 767) {
                 return 27;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -289,7 +305,7 @@ public final class MetaOffsetConverter {
 
         public static byte textBackgroundColorOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 766) {
+            if (protocolVersion >= 764 && protocolVersion <= 767) {
                 return 28;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -300,7 +316,7 @@ public final class MetaOffsetConverter {
 
         public static byte textBackgroundOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 766) {
+            if (protocolVersion >= 764 && protocolVersion <= 767) {
                 return 29;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -311,7 +327,7 @@ public final class MetaOffsetConverter {
 
         public static byte textScaleOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 766) {
+            if (protocolVersion >= 764 && protocolVersion <= 767) {
                 return 30;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -322,10 +338,10 @@ public final class MetaOffsetConverter {
 
         public static byte textAlignmentOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 766) {
+            if (protocolVersion >= 764 && protocolVersion <= 767) {
                 return 31;
             }
-            if (protocolVersion >= 762 && protocolVersion <= 763) {
+            if (protocolVersion >= 762 && protocolVersion <= 767) {
                 return 30;
             }
             throw new RuntimeException("Unknown protocol version for this method");
@@ -333,7 +349,7 @@ public final class MetaOffsetConverter {
 
         public static byte lineWidthOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 766) {
+            if (protocolVersion >= 764 && protocolVersion <= 767) {
                 return 32;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -344,7 +360,7 @@ public final class MetaOffsetConverter {
 
         public static byte backgroundColorOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 766) {
+            if (protocolVersion >= 764 && protocolVersion <= 767) {
                 return 33;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -355,7 +371,7 @@ public final class MetaOffsetConverter {
 
         public static byte textOpacityOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 766) {
+            if (protocolVersion >= 764 && protocolVersion <= 767) {
                 return 34;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -366,7 +382,7 @@ public final class MetaOffsetConverter {
 
         public static byte shadowOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 766) {
+            if (protocolVersion >= 764 && protocolVersion <= 767) {
                 return 35;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -377,7 +393,7 @@ public final class MetaOffsetConverter {
 
         public static byte seeThroughOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 766) {
+            if (protocolVersion >= 764 && protocolVersion <= 767) {
                 return 36;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -388,7 +404,7 @@ public final class MetaOffsetConverter {
 
         public static byte useDefaultBackgroundOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 766) {
+            if (protocolVersion >= 764 && protocolVersion <= 767) {
                 return 37;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -399,7 +415,7 @@ public final class MetaOffsetConverter {
 
         public static byte allighnLeftOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 766) {
+            if (protocolVersion >= 764 && protocolVersion <= 767) {
                 return 38;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -410,7 +426,7 @@ public final class MetaOffsetConverter {
 
         public static byte allighnRightOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 766) {
+            if (protocolVersion >= 764 && protocolVersion <= 767) {
                 return 39;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {
@@ -421,7 +437,7 @@ public final class MetaOffsetConverter {
 
         public static byte allighnCenterOffset() {
             int protocolVersion = getApi().getPacketEvents().getServerManager().getVersion().getProtocolVersion();
-            if (protocolVersion >= 764 && protocolVersion <= 766) {
+            if (protocolVersion >= 764 && protocolVersion <= 767) {
                 return 40;
             }
             if (protocolVersion >= 762 && protocolVersion <= 763) {

--- a/api/src/main/java/me/tofaa/entitylib/meta/mobs/monster/BreezeMeta.java
+++ b/api/src/main/java/me/tofaa/entitylib/meta/mobs/monster/BreezeMeta.java
@@ -1,0 +1,15 @@
+package me.tofaa.entitylib.meta.mobs.monster;
+
+import me.tofaa.entitylib.meta.Metadata;
+import me.tofaa.entitylib.meta.types.MobMeta;
+
+public class BreezeMeta extends MobMeta {
+
+    public static final byte OFFSET = MobMeta.MAX_OFFSET;
+    public static final byte MAX_OFFSET = OFFSET + 0;
+
+    public BreezeMeta(int entityId, Metadata metadata) {
+        super(entityId, metadata);
+    }
+
+}

--- a/api/src/main/java/me/tofaa/entitylib/meta/mobs/monster/skeleton/BoggedMeta.java
+++ b/api/src/main/java/me/tofaa/entitylib/meta/mobs/monster/skeleton/BoggedMeta.java
@@ -1,0 +1,11 @@
+package me.tofaa.entitylib.meta.mobs.monster.skeleton;
+
+import me.tofaa.entitylib.meta.Metadata;
+
+public class BoggedMeta extends SkeletonMeta {
+
+    public BoggedMeta(int entityId, Metadata metadata) {
+        super(entityId, metadata);
+    }
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -11,14 +11,14 @@ allprojects {
                                          "net.kyori:adventure-text-serializer-legacy:${adventureVersion}",
                                          "net.kyori:adventure-nbt:${adventureVersion}"]
 
-    project.ext.peVersion = '2.3.0'
+    project.ext.peVersion = '2.4.0'
 
     apply plugin: 'java'
     apply plugin: 'java-library'
     apply plugin: 'maven-publish'
 
     group = 'me.tofaa.entitylib'
-    version = '2.0-SNAPSHOT'
+    version = '2.3.1-SNAPSHOT'
 
     java.sourceCompatibility = JavaVersion.VERSION_1_8
     java.targetCompatibility = JavaVersion.VERSION_1_8
@@ -61,6 +61,6 @@ allprojects {
 
 
 dependencies {
-    compileOnlyApi 'com.github.retrooper.packetevents:spigot:${project.ext.peVersion}'
+    compileOnlyApi 'com.github.retrooper:packetevents-spigot:${project.ext.peVersion}'
 }
 

--- a/code-gen/src/main/resources/offset-calculator.json
+++ b/code-gen/src/main/resources/offset-calculator.json
@@ -6,7 +6,7 @@
         "name": "airTicks",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 47,
             "offset": 1
           }
@@ -16,7 +16,7 @@
         "name": "customName",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 47,
             "offset": 2
           }
@@ -26,7 +26,7 @@
         "name": "customNameVisible",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 47,
             "offset": 3
           }
@@ -36,7 +36,7 @@
         "name": "silent",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 47,
             "offset": 4
           }
@@ -46,7 +46,7 @@
         "name": "hasNoGravity",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 47,
             "offset": 5
           }
@@ -56,7 +56,7 @@
         "name": "pose",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 47,
             "offset": 6
           }
@@ -66,7 +66,7 @@
         "name": "ticksFrozenInPowderedSnow",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 47,
             "offset": 7
           }
@@ -84,7 +84,7 @@
         "name": "interpolationDelay",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 762,
             "offset": 8
           }
@@ -94,7 +94,7 @@
         "name": "transformationDuration",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 762,
             "offset": 9
           }
@@ -104,7 +104,7 @@
         "name": "positionRotationInterpolationDuration",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 764,
             "offset": 10
           }
@@ -114,7 +114,7 @@
         "name": "translation",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 764,
             "offset": 11
           },
@@ -129,7 +129,7 @@
         "name": "scale",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 764,
             "offset": 12
           },
@@ -144,7 +144,7 @@
         "name": "leftRotation",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 764,
             "offset": 13
           },
@@ -159,7 +159,7 @@
         "name": "rightRotation",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 764,
             "offset": 14
           },
@@ -174,7 +174,7 @@
         "name": "billboardConstraints",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 764,
             "offset": 15
           },
@@ -189,7 +189,7 @@
         "name": "brightnessOverride",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 764,
             "offset": 16
           },
@@ -204,7 +204,7 @@
         "name": "viewRange",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 764,
             "offset": 17
           },
@@ -219,7 +219,7 @@
         "name": "shadowRadius",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 764,
             "offset": 18
           },
@@ -234,7 +234,7 @@
         "name": "shadowStrength",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 764,
             "offset": 19
           },
@@ -249,7 +249,7 @@
         "name": "width",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 764,
             "offset": 20
           },
@@ -264,7 +264,7 @@
         "name": "height",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 764,
             "offset": 21
           },
@@ -279,7 +279,7 @@
         "name": "glowColorOverride",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 764,
             "offset": 22
           },
@@ -299,7 +299,7 @@
         "name": "blockId",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 764,
             "offset": 23
           },
@@ -319,7 +319,7 @@
         "name": "item",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 764,
             "offset": 24
           },
@@ -334,7 +334,7 @@
         "name": "displayType",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 764,
             "offset": 25
           },
@@ -354,7 +354,7 @@
         "name": "text",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 764,
             "offset": 26
           },
@@ -369,7 +369,7 @@
         "name": "textColor",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 764,
             "offset": 27
           },
@@ -384,7 +384,7 @@
         "name": "textBackgroundColor",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 764,
             "offset": 28
           },
@@ -399,7 +399,7 @@
         "name": "textBackground",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 764,
             "offset": 29
           },
@@ -414,7 +414,7 @@
         "name": "textScale",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 764,
             "offset": 30
           },
@@ -429,12 +429,12 @@
         "name": "textAlignment",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 764,
             "offset": 31
           },
           {
-            "from": 763,
+            "from": 767,
             "to": 762,
             "offset": 30
           }
@@ -444,7 +444,7 @@
         "name": "lineWidth",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 764,
             "offset": 32
           },
@@ -459,7 +459,7 @@
         "name": "backgroundColor",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 764,
             "offset": 33
           },
@@ -474,7 +474,7 @@
           "name": "textOpacity",
           "checks": [
             {
-                "from": 765,
+                "from": 767,
                 "to": 764,
                 "offset": 34
             },
@@ -489,7 +489,7 @@
         "name": "shadow",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 764,
             "offset": 35
           },
@@ -504,7 +504,7 @@
         "name": "seeThrough",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 764,
             "offset": 36
           },
@@ -519,7 +519,7 @@
             "name": "useDefaultBackground",
             "checks": [
             {
-                "from": 765,
+                "from": 767,
                 "to": 764,
                 "offset": 37
             },
@@ -534,7 +534,7 @@
         "name": "allighnLeft",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 764,
             "offset": 38
           },
@@ -549,7 +549,7 @@
         "name": "allighnRight",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 764,
             "offset": 39
           },
@@ -564,7 +564,7 @@
         "name": "allighnCenter",
         "checks": [
           {
-            "from": 765,
+            "from": 767,
             "to": 764,
             "offset": 40
           },

--- a/platforms/spigot/build.gradle
+++ b/platforms/spigot/build.gradle
@@ -1,6 +1,6 @@
 
 dependencies {
     api(project(":common"))
-    compileOnly('com.github.retrooper.packetevents:spigot:' + peVersion)
-    compileOnly('org.spigotmc:spigot-api:1.20.1-R0.1-SNAPSHOT')
+    compileOnly('com.github.retrooper:packetevents-spigot:' + peVersion)
+    compileOnly('org.spigotmc:spigot-api:1.21-R0.1-SNAPSHOT')
 }

--- a/test-plugin/build.gradle
+++ b/test-plugin/build.gradle
@@ -7,10 +7,10 @@ plugins {
 
 group = 'me.tofaa.peentitymeta'
 version = '1.0-SNAPSHOT'
-// java 17
+// java 21
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
 
@@ -31,16 +31,16 @@ repositories {
 }
 
 dependencies {
-    compileOnly('org.spigotmc:spigot-api:1.20.1-R0.1-SNAPSHOT')
-    compileOnly('com.github.retrooper.packetevents:spigot:2.3.0')
+    compileOnly('org.spigotmc:spigot-api:1.21-R0.1-SNAPSHOT')
+    compileOnly('com.github.retrooper:packetevents-spigot:' + peVersion)
 //    implementation(project(":platforms:spigot"))
     implementation(project(":platforms:spigot"))
 }
 
 
 runServer {
-    minecraftVersion("1.20.4")
+    minecraftVersion("1.21")
     downloadPlugins {
-        modrinth("packetevents", "6Rjr7zyF")
+        modrinth("packetevents", "MfD5eOYA")
     }
 }

--- a/test-plugin/src/main/resources/plugin.yml
+++ b/test-plugin/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ version: 1.0.0
 depend:
   - packetevents
 main: me.tofaa.testentitylib.TestEntityLibPlugin
-api-version: "1.19"
+api-version: "1.21"
 commands:
   testapi:
     description: Test EntityLib API


### PR DESCRIPTION
This PR adds support for PacketEvents 2.4.0 as well as Minecraft 1.21, though the tests I used aren't included on it but will be included on another one so they can be evaluated separately, BoggedMeta and BreezeMeta don't really add anything specific to their mob types as I wasn't able to find documentation about them.

Further testing should be done to be able to tell if this is actually stable on 1.21, but I actually used pretty much every method from the MetaOffsetConverter class on 1.21 and everything seemed to work fine.