### PR TITLE
[Fix] BlockDisplay should use BLOCK_STATE not INT

### DIFF
--- a/api/src/main/java/me/tofaa/entitylib/meta/display/BlockDisplayMeta.java
+++ b/api/src/main/java/me/tofaa/entitylib/meta/display/BlockDisplayMeta.java
@@ -17,7 +17,7 @@ public class BlockDisplayMeta extends AbstractDisplayMeta {
     }
 
     public void setBlockId(int blockId) {
-        super.metadata.setIndex(OFFSET, EntityDataTypes.INT, blockId);
+        super.metadata.setIndex(OFFSET, EntityDataTypes.BLOCK_STATE, blockId);
     }
 
 }


### PR DESCRIPTION
For BlockDisplay blocks to display, we need to send a BLOCK_STATE and not a regular INT. Client can not parse integer to block state so it disconnects itself.

Relevant wiki.vg entry:
https://wiki.vg/Entity_metadata#Block_Display