### PR TITLE
Avoid returning empty optional velocity for entity spawn packets

### DIFF
--- a/api/src/main/java/me/tofaa/entitylib/wrapper/WrapperEntity.java
+++ b/api/src/main/java/me/tofaa/entitylib/wrapper/WrapperEntity.java
@@ -123,7 +123,7 @@ public class WrapperEntity implements Tickable {
             }
         }
         if (veloX == 0 && veloY == 0 && veloZ == 0) {
-            velocity = Optional.empty();
+            velocity = Optional.of(Vector3d.zero());
         } else {
             velocity = Optional.of(new Vector3d(veloX, veloY, veloZ));
         }


### PR DESCRIPTION
When using an empty optional within the spawn entity packet, a velocity of -1 is applied on all axes due to [this line](https://github.com/retrooper/packetevents/blob/97dcbc606ea704c253f11cc6a33f3ee87c862715/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerSpawnEntity.java#L183) in PacketEvents. This affects entities that are exclusively client-side updated (e.g., fireworks), while other entities remain unaffected as they rely on the server for position updates.

Before fix:

https://github.com/user-attachments/assets/7e49915b-071d-46b7-9b90-66935dcee7bc


After fix:

https://github.com/user-attachments/assets/5e5cccdb-6ce6-4604-8452-bb1922c3c0ec

In addition, you could have fireworks implement the ObjectData interface so that spawn velocity can be customized. This would allow more flexibility - for example, creating fireworks that can move diagonally. From the little time I had to check, this would also make the "shot at angle" metadata work properly.