### PR TITLE
Resend entity passengers when a new viewer is added

### DIFF
--- a/api/src/main/java/me/tofaa/entitylib/wrapper/WrapperEntity.java
+++ b/api/src/main/java/me/tofaa/entitylib/wrapper/WrapperEntity.java
@@ -195,6 +195,7 @@ public class WrapperEntity implements Tickable {
             }
             sendPacket(uuid, createSpawnPacket());
             sendPacket(uuid, entityMeta.createPacket());
+            sendPacket(uuid, createPassengerPacket());
         }
         if (EntityLib.getApi().getSettings().isDebugMode()) {
             EntityLib.getPlatform().getLogger().info("Added viewer " + uuid + " to entity " + entityId);


### PR DESCRIPTION
This fixes an issue where the passenger packet wasn't being resent when a new viewer was added to an already spawned entity. The problem was especially noticeable when updating the texture properties of a WrapperPlayer, as the entity destroy/respawn sequence would result in missing passenger data.

Before:

https://github.com/user-attachments/assets/44c01e5d-19ca-4d65-abed-72df8e80288c

https://github.com/user-attachments/assets/eddf25aa-8906-4455-9247-f2030f3cdf98

After:


https://github.com/user-attachments/assets/977f1b4e-1dc0-4025-862d-460fcf92d4a4


https://github.com/user-attachments/assets/5a3a52ed-fa10-4ca7-a8e3-836a6de6376b

