### PR TITLE
Initialize velocity variable for new wrapper entity

### DIFF
--- a/api/src/main/java/me/tofaa/entitylib/wrapper/WrapperEntity.java
+++ b/api/src/main/java/me/tofaa/entitylib/wrapper/WrapperEntity.java
@@ -52,6 +52,7 @@ public class WrapperEntity implements Tickable {
         this.passengers = ConcurrentHashMap.newKeySet();
         this.location = new Location(0, 0, 0, 0, 0);
         this.viewerRules = new CopyOnWriteArrayList<>();
+        this.velocity = Vector3d.zero();
     }
 
     public WrapperEntity(int entityId, EntityType entityType) {


### PR DESCRIPTION
The velocity variable is never set in the class construction, resulting in null pointer exception if the getVelocityPacket method try to change it when is called, and the variable is not set before-hand using the setVelocity method.

The error log:
```
java.lang.NullPointerException: Cannot invoke "com.github.retrooper.packetevents.util.Vector3d.multiply(double)" because "this.velocity" is null
    at Typewriter.jar/me.tofaa.entitylib.wrapper.WrapperEntity.getVelocityPacket(WrapperEntity.java:402) ~[Typewriter.jar:?]
    at Typewriter.jar/me.tofaa.entitylib.wrapper.WrapperEntity.createVeloPacket(WrapperEntity.java:122) ~[Typewriter.jar:?]
    at Typewriter.jar/me.tofaa.entitylib.wrapper.WrapperEntity.spawn(WrapperEntity.java:86) ~[Typewriter.jar:?]
    at Typewriter.jar/me.tofaa.entitylib.wrapper.WrapperEntity.spawn(WrapperEntity.java:104) ~[Typewriter.jar:?]
    at com.typewritermc.entity.entries.entity.WrapperFakeEntity.spawn(WrapperFakeEntity.kt:58) ~[?:?]
```
