### PR TITLE
Fix client disconnections caused by incorrect metadata offsets in horse packets

### DIFF
--- a/api/src/main/java/me/tofaa/entitylib/meta/mobs/horse/BaseHorseMeta.java
+++ b/api/src/main/java/me/tofaa/entitylib/meta/mobs/horse/BaseHorseMeta.java
@@ -1,16 +1,12 @@
 package me.tofaa.entitylib.meta.mobs.horse;
 
-import com.github.retrooper.packetevents.protocol.entity.data.EntityDataTypes;
 import me.tofaa.entitylib.meta.Metadata;
-import me.tofaa.entitylib.meta.types.MobMeta;
+import me.tofaa.entitylib.meta.types.AgeableMeta;
 
-import java.util.Optional;
-import java.util.UUID;
+public abstract class BaseHorseMeta extends AgeableMeta {
 
-public abstract class BaseHorseMeta extends MobMeta {
-
-    public static final byte OFFSET = MobMeta.MAX_OFFSET;
-    public static final byte MAX_OFFSET = OFFSET + 2;
+    public static final byte OFFSET = AgeableMeta.MAX_OFFSET;
+    public static final byte MAX_OFFSET = OFFSET + 1;
 
     private final static byte TAMED_BIT = 0x02;
     private final static byte SADDLED_BIT = 0x04;
@@ -70,13 +66,4 @@ public abstract class BaseHorseMeta extends MobMeta {
     public void setMouthOpen(boolean value) {
         setMaskBit(OFFSET, MOUTH_OPEN_BIT, value);
     }
-
-    public Optional<UUID> getOwner() {
-        return super.metadata.getIndex(offset(OFFSET, 1), Optional.empty());
-    }
-
-    public void setOwner(UUID value) {
-        super.metadata.setIndex(offset(OFFSET, 1), EntityDataTypes.OPTIONAL_UUID, Optional.of(value));
-    }
-
 }


### PR DESCRIPTION
This PR resolves an issue where clients would disconnect when receiving horse entity metadata packets.

Previously, `BaseHorseMeta` inherited from `MobMeta` and implemented methods for setting/getting an Owner UUID. However, vanilla Minecraft's `AbstractHorse` class does not synchronize the owner between server and client (unlike `TamableAnimal` which does). This difference meant that when sending packets, the data was positioned at indices the client didn't expect for horses, causing misalignment and disconnections.

This fix changes `BaseHorseMeta` to inherit from `AgeableMeta` instead, which correctly aligns the starting metadata index with vanilla's structure for horses. The non-functional `getOwner()` and `setOwner()` methods have been removed as they were relying on non-existent synchronized data.

These changes also properly enable the baby flag functionality for horses and related entities to work.