### PR TITLE
fix(meta): remove ThrownTridentMeta registration from registry POTION

### DIFF
--- a/api/src/main/java/me/tofaa/entitylib/meta/MetaConverterRegistry.java
+++ b/api/src/main/java/me/tofaa/entitylib/meta/MetaConverterRegistry.java
@@ -124,7 +124,6 @@ final class MetaConverterRegistry {
         put(PILLAGER, PillagerMeta.class, PillagerMeta::new);
         put(PLAYER, PlayerMeta.class, PlayerMeta::new);
         put(POLAR_BEAR, PolarBearMeta.class, PolarBearMeta::new);
-        put(POTION, ThrownTridentMeta.class, ThrownTridentMeta::new);
         put(PRIMED_TNT, PrimedTntMeta.class, PrimedTntMeta::new);
         put(PUFFERFISH, PufferFishMeta.class, PufferFishMeta::new);
         put(RABBIT, RabbitMeta.class, RabbitMeta::new);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the entity type mapping for POTION to ensure it is properly associated with ThrownPotionMeta.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->