### PR TITLE
Use registry for cat and wolf variant

### DIFF
--- a/api/src/main/java/me/tofaa/entitylib/meta/mobs/tameable/CatMeta.java
+++ b/api/src/main/java/me/tofaa/entitylib/meta/mobs/tameable/CatMeta.java
@@ -1,5 +1,7 @@
 package me.tofaa.entitylib.meta.mobs.tameable;
 
+import com.github.retrooper.packetevents.protocol.entity.cat.CatVariant;
+import com.github.retrooper.packetevents.protocol.entity.cat.CatVariants;
 import com.github.retrooper.packetevents.protocol.entity.data.EntityDataTypes;
 import me.tofaa.entitylib.extras.DyeColor;
 import me.tofaa.entitylib.meta.Metadata;
@@ -20,11 +22,12 @@ public class CatMeta extends TameableMeta {
 
     @NotNull
     public CatMeta.Variant getVariant() {
-        return super.metadata.getIndex(OFFSET, Variant.BLACK);
+        final CatVariant catVariant = super.metadata.getIndex(OFFSET, CatVariants.BLACK);
+        return Variant.fromCatVariant(catVariant);
     }
 
     public void setVariant(@NotNull CatMeta.Variant value) {
-        super.metadata.setIndex(OFFSET, EntityDataTypes.CAT_VARIANT, value.ordinal());
+        super.metadata.setIndex(OFFSET, EntityDataTypes.TYPED_CAT_VARIANT, value.getCatVariant());
     }
 
     public boolean isLying() {
@@ -51,21 +54,40 @@ public class CatMeta extends TameableMeta {
         super.metadata.setIndex(offset(OFFSET, 3), EntityDataTypes.INT, value.ordinal());
     }
 
-
     public enum Variant {
-        TABBY,
-        BLACK,
-        RED,
-        SIAMESE,
-        BRITISH_SHORTHAIR,
-        CALICO,
-        PERSIAN,
-        RAGDOLL,
-        WHITE,
-        JELLIE,
-        ALL_BLACK;
+        ALL_BLACK(CatVariants.ALL_BLACK),
+        BLACK(CatVariants.BLACK),
+        BRITISH_SHORTHAIR(CatVariants.BRITISH_SHORTHAIR),
+        CALICO(CatVariants.CALICO),
+        JELLIE(CatVariants.JELLIE),
+        PERSIAN(CatVariants.PERSIAN),
+        RAGDOLL(CatVariants.RAGDOLL),
+        RED(CatVariants.RED),
+        SIAMESE(CatVariants.SIAMESE),
+        TABBY(CatVariants.TABBY),
+        WHITE(CatVariants.WHITE);
+
+        private final CatVariant catVariant;
+
+        Variant(final CatVariant catVariant) {
+            this.catVariant = catVariant;
+        }
 
         private static final Variant[] VALUES = values();
+
+        public CatVariant getCatVariant() {
+            return catVariant;
+        }
+
+        @NotNull
+        public static Variant fromCatVariant(@NotNull final CatVariant catVariant) {
+            for (final Variant variant : VALUES) {
+                if (variant.getCatVariant().equals(catVariant)) {
+                    return variant;
+                }
+            }
+            return BLACK;
+        }
     }
 
 }

--- a/api/src/main/java/me/tofaa/entitylib/meta/mobs/tameable/WolfMeta.java
+++ b/api/src/main/java/me/tofaa/entitylib/meta/mobs/tameable/WolfMeta.java
@@ -1,17 +1,29 @@
 package me.tofaa.entitylib.meta.mobs.tameable;
 
 import com.github.retrooper.packetevents.protocol.entity.data.EntityDataTypes;
+import com.github.retrooper.packetevents.protocol.entity.wolfvariant.WolfVariant;
+import com.github.retrooper.packetevents.protocol.entity.wolfvariant.WolfVariants;
 import me.tofaa.entitylib.extras.DyeColor;
 import me.tofaa.entitylib.meta.Metadata;
 import me.tofaa.entitylib.meta.types.TameableMeta;
+import org.jetbrains.annotations.NotNull;
 
 public class WolfMeta extends TameableMeta {
 
     public static final byte OFFSET = TameableMeta.MAX_OFFSET;
-    public static final byte MAX_OFFSET = OFFSET + 3;
+    public static final byte MAX_OFFSET = OFFSET + 5;
 
     public WolfMeta(int entityId, Metadata metadata) {
         super(entityId, metadata);
+    }
+
+    @NotNull
+    public WolfVariant getVariant() {
+        return super.metadata.getIndex(offset(OFFSET, 3), WolfVariants.PALE);
+    }
+
+    public void setVariant(@NotNull WolfVariant value) {
+        super.metadata.setIndex(offset(OFFSET, 3), EntityDataTypes.TYPED_WOLF_VARIANT, value);
     }
 
     public boolean isBegging() {


### PR DESCRIPTION
To address an issue with cat variants, this pull request updates how their metadata is handled. Previously, the system used the enum's ordinal value for the metadata packet. This caused the wrong variant to be applied to the entity because cat variants are stored in the registry.

To fix this, the code now uses the cat variant registry provided by packet events. To maintain backward compatibility with older API versions, the enum has been mapped to the corresponding registry.

Additionally, since wolves also have variants, a corresponding method for them has been added. This required updating the maximum offset to account for two extra fields: one for the variant and one for the sound variant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added get/set support for wolf variants.
  * Upgraded cat variant handling to use typed variant objects for more accurate variant representation.

* **API Changes**
  * New public methods to manage wolf variants.
  * Cat variant API changed from ordinal-based values to typed variant objects for consistent retrieval and storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->