### PR TITLE
Fix the rendered packet overwrites the original metadata

### DIFF
--- a/api/src/main/java/me/tofaa/entitylib/utils/PacketUtil.java
+++ b/api/src/main/java/me/tofaa/entitylib/utils/PacketUtil.java
@@ -4,6 +4,7 @@ import com.github.retrooper.packetevents.protocol.entity.data.EntityData;
 import com.github.retrooper.packetevents.protocol.entity.data.EntityDataTypes;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerEntityMetadata;
 import me.tofaa.entitylib.EntityLib;
+import java.util.ArrayList;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
@@ -15,6 +16,11 @@ public class PacketUtil {
     }
 
     public static void renderPacket(UUID user, WrapperPlayServerEntityMetadata metadata) {
+        final ArrayList<EntityData<?>> copiedEntityData = new ArrayList<>();
+        metadata.getEntityMetadata().forEach(entityData ->
+                copiedEntityData.add(new EntityData(entityData.getIndex(), entityData.getType(), entityData.getValue()))
+        );
+        metadata.setEntityMetadata(copiedEntityData);
         Locale locale = EntityLib.getApi().getUserLocaleProvider().locale(user);
         for (final EntityData<?> entityData : metadata.getEntityMetadata()) {
             if (entityData.getType() == EntityDataTypes.ADV_COMPONENT) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where entity metadata could be unintentionally modified during packet rendering, preventing inconsistent visuals and state leaks.
* **Refactor**
  * Improved metadata handling by isolating processing to a safe copy, enhancing stability without altering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->