### PR TITLE
Fix Viewer Engine incorrectly evaluating rules

### DIFF
--- a/api/src/main/java/me/tofaa/entitylib/ve/ViewerEngine.java
+++ b/api/src/main/java/me/tofaa/entitylib/ve/ViewerEngine.java
@@ -121,8 +121,19 @@ public class ViewerEngine {
      * @return true if the user passed and did not fail any rules, false otherwise
      */
     public boolean canSpawnFor(User user, WrapperEntity entity) {
-        if (!entity.getViewerRules().isEmpty() && entity.getViewerRules().stream().allMatch(rule -> rule.shouldSee(user))) return true;
-        return globalRules.stream().allMatch(rule -> rule.shouldSee(user));
+        for (ViewerRule rule : entity.getViewerRules()) {
+            if (!rule.shouldSee(user)) {
+                return false;
+            }
+        }
+
+        for (ViewerRule rule : this.globalRules) {
+            if (!rule.shouldSee(user)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
Viewer Engine would incorrectly evaluate rules on the following evaluations:
 - If all entity rules passed, global rules would be ignored
 - If an entity rule failed, it would then check if global rules passed, instead of returning false
 - If an entity rule failed, and the global rules were empty, it would always return true

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal performance optimization in entity visibility handling logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Tofaa2/EntityLib/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->