### PR TITLE
Add Configurable EntityContainer instead of always using basic

### DIFF
--- a/api/src/main/java/me/tofaa/entitylib/APIConfig.java
+++ b/api/src/main/java/me/tofaa/entitylib/APIConfig.java
@@ -2,7 +2,9 @@ package me.tofaa.entitylib;
 
 import com.github.retrooper.packetevents.PacketEventsAPI;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
+import me.tofaa.entitylib.container.EntityContainer;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public final class APIConfig {
 
@@ -13,6 +15,7 @@ public final class APIConfig {
     private boolean platformLogger = false;
     private boolean bstats = true;
     private boolean forceBundle = false;
+    private EntityContainer entityContainer;
 
     public APIConfig(PacketEventsAPI<?> packetEvents) {
         this.packetEvents = packetEvents;
@@ -53,6 +56,11 @@ public final class APIConfig {
         return this;
     }
 
+    public @NotNull APIConfig entityContainer(EntityContainer container) {
+        this.entityContainer = container;
+        return this;
+    }
+
     public boolean isDebugMode() {
         return debugMode;
     }
@@ -81,6 +89,11 @@ public final class APIConfig {
         return this.forceBundle
                 && EntityLib.getOptionalApi().isPresent()
                 && EntityLib.getOptionalApi().get().getPacketEvents().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_19_4);
+    }
+
+    @Nullable
+    public EntityContainer getEntityContainer() {
+        return this.entityContainer;
     }
 
 }

--- a/common/src/main/java/me/tofaa/entitylib/common/AbstractEntityLibAPI.java
+++ b/common/src/main/java/me/tofaa/entitylib/common/AbstractEntityLibAPI.java
@@ -21,13 +21,16 @@ public abstract class AbstractEntityLibAPI<P, T> implements EntityLibAPI<T> {
     protected final PacketEventsAPI<?> packetEvents;
     protected final APIConfig settings;
     protected final Collection<TickContainer<?, T>> tickContainers;
-    protected final EntityContainer defaultEntityContainer = EntityContainer.basic();
+    protected final EntityContainer defaultEntityContainer;
 
     protected AbstractEntityLibAPI(Platform<P> platform, APIConfig settings) {
         this.platform = platform;
         this.packetEvents = settings.getPacketEvents();
         this.settings = settings;
         this.tickContainers = settings.shouldTickTickables() ? new HashSet<>() : Collections.emptyList();
+
+        EntityContainer container = settings.getEntityContainer();
+        this.defaultEntityContainer = container == null ? EntityContainer.basic() : container;
     }
 
     @Override


### PR DESCRIPTION
The AbstractEntityLibAPI would constantly use the basic implementation of the EntityContainer. This PR allows developers to specify another one, and track entities themselves.

If a custom EntityContainer is not provided, it'll simply default to the basic implementation, keeping backwards compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * APIConfig now supports EntityContainer configuration, enabling customization of entity handling with automatic fallback to default settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Tofaa2/EntityLib/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->